### PR TITLE
Fix typos

### DIFF
--- a/01_Introduction.org
+++ b/01_Introduction.org
@@ -10,7 +10,7 @@
 both an introduction and a reference manual for programming in the
 Lean theorem prover.
 
-We are making this material public now now because currently it is the
+We are making this material public now because currently it is the
 only existing documentation for many of the specifics of the Lean
 programming language and its API, and we are hoping that the
 information will be useful to brave souls experimenting with it at
@@ -52,7 +52,7 @@ the language can be evaluated efficiently by Lean's virtual-machine
 interpreter or translated automatically to C++ and compiled.
 
 Viewed from a computational perspective, the Calculus of Inductive
-Construtions is an instance of a purely functional programming
+Constructions is an instance of a purely functional programming
 language. This means that a program in Lean is simply an expression
 whose value is determined compositionally from the values of the other
 expressions it refers to, independent of any sort of ambient state of
@@ -69,7 +69,7 @@ terminating. So, for example, every "while" loop has to be explicitly
 bounded, though, of course, we can consider the result of iterating an
 arbitrary computation =n= times for any given natural number =n=. We
 will see that Lean provides flexible mechanisms for structural and
-well-founded recursion, allowing us to to define functions in natural
+well-founded recursion, allowing us to define functions in natural
 ways. At the same, the system provides complementary mechanisms for
 proving claims, using inductive principles that capture the structure
 of the function definitions.
@@ -82,7 +82,7 @@ For example...
 
 [Define operations on lists.]
 
-[Prove things, like ~length (reverse l) = reverse l~ or ~reverse
+[Prove things, like ~length (reverse l) = length l~ or ~reverse
 (reverse l) = l~.]
 
 ** Input and Output
@@ -126,7 +126,7 @@ foundation. From the latter's perspective, the type constructor =IO=
 and the functions =put_str= and =get_str= are entirely opaque, objects
 about which that the axiomatic system has nothing to say. The =print
 axioms= command shows that the expression =hello world= depends on the
-contants =IO= and =put_str=, which have been forcibly added to the
+constants =IO= and =put_str=, which have been forcibly added to the
 axiomatic system.
 #+BEGIN_SRC lean
 import system.IO

--- a/07_Monads.org
+++ b/07_Monads.org
@@ -12,7 +12,7 @@ equipped with two special operations, =return= and =bind=. If =A= is
 any type, think of =m A= as being a "virtual =A=," or, as some people
 describe it, "an =A= inside a box." 
 
-For a given monoid =m=, the function =return= has type =Π {A : Type},
+For a given monad =m=, the function =return= has type =Π {A : Type},
 A → m A=. The idea is that for any element =a : A=, =return a=
 produces the virtual version of =a=, or puts =a= inside the box.
 
@@ -193,7 +193,7 @@ in the list.
 It is easy to insert a value =a : A= into =list A=; we define =return
 a= to be just the singleton list =[a]=. Now, given =la : list A= and
 =f : A → list B=, how should we define the bind operation ~la >>= f~?
-Intuitively, =la= represents any of the possible values occuring in
+Intuitively, =la= represents any of the possible values occurring in
 the list, and for each such element =a=, =f= may return any of the
 elements in =f a=. We can then gather all the possible values of the
 virtual application by applying =f= to each element of =la= and
@@ -270,7 +270,7 @@ read and write values. (To avoid questions as to how we would
 interpret the flow of control in terms like =h (k₁ a) (k₂ a)=, let us
 suppose that we only care about composing unary functions.)
 
-There is a straightfoward way to implement this behavior in a
+There is a straightforward way to implement this behavior in a
 functional programming language, namely, by making the state of the
 three registers an explicit argument. First, let us define a data
 structure to hold the three values, and define the initial settings:
@@ -533,7 +533,7 @@ to the user, and that the expressions are printed in the right order.
 import system.IO
 
 -- BEGIN
-vm_eval do put_str "hello " >> put_str "world!" >> put_nat (27 * 39)
+vm_eval put_str "hello " >> put_str "world!" >> put_nat (27 * 39)
 -- END
 #+END_SRC
 
@@ -592,7 +592,7 @@ end hide
 #+END_SRC
 The =monad= class extends both =functor= and =applicative=, so both of
 these can be seen as even more abstract versions of =monad=. On the
-other hand, not every =monad= is alternative, and in the next chapter
+other hand, not every =monad= is =alternative=, and in the next chapter
 we will see an important example of one that is. One way to think
 about an alternative monad is to think of it as representing
 computations that can possibly fail, and, moreover, Intuitively, an

--- a/08_Writing_Tactics.org
+++ b/08_Writing_Tactics.org
@@ -176,7 +176,7 @@ by do eH1 ← intro `H1,
       exact eH2
 -- END
 #+END_SRC
-The double backticks will also be explained below, but the general
+The double-backticks will also be explained below, but the general
 idea is that the third line of the tactic builds an =expr= that
 reflects the =and.intro= declaration in the Lean environment, and
 applies it. We can also finish the proof as follows:


### PR DESCRIPTION
Besides from the typos, I realized that
* the code `--vm_eval foo` in Chap. 1 does not make sense because the vm only evaluates ground typed expressions.  Maybe something like `--vm_eval foo 0` would be better.  Actually evaluating this code crashed my browser (as expected), and I'm not sure if it's a good thing to add a dangerous code in the snippet. 
* in my local environment `import system.IO` doesn't work. This is because the path environment is case sensitive and the name of the file is `library/system/io.lean` (at least in the latest version). However the code works when using a browser.

This PR does *not* fix the above-mentioned issues.